### PR TITLE
Add resetmap getter

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -60,6 +60,7 @@ out_transitions
 ### Guards and Assignments
 
 ```@docs
+resetmap
 guard
 assignment
 ```

--- a/src/HybridSystems.jl
+++ b/src/HybridSystems.jl
@@ -17,17 +17,7 @@ abstract type AbstractHybridSystem <: MathematicalSystems.AbstractSystem end
 """
     HybridSystem{A, S, R, W} <: AbstractHybridSystem
 
-A hybrid system modelled as a hybrid automaton. The automaton `automaton` of
-type `A` models the different discrete states and the allowed transitions with
-corresponding labels.
-The mode dynamic and domain are stored in a continuous dynamical system of type
-`S` in the vector `modes`. They are indexed by the discrete states of the
-automaton.
-The reset maps and guards are given as a map of type `R` in the vector `resetmaps`.
-They are indexed by the labels of the corresponding transition.
-The switching of type `W` is given in the `switchings` vector,
-indexed by the label of the transition.
-Additional data can be stored in the `ext` field.
+A hybrid system modelled as a hybrid automaton.
 
 ### Fields
 
@@ -42,11 +32,29 @@ Additional data can be stored in the `ext` field.
                   transition, see [`AbstractSwitching`](@ref).
 - `ext`        -- dictionary that can be used by extensions.
 
+### Notes
+
+The automaton `automaton` of type `A` models the different discrete states and
+the allowed transitions with corresponding labels.
+
+The mode dynamic and domain are stored in a continuous dynamical system of type
+`S` in the vector `modes`. They are indexed by the discrete states of the
+automaton.
+
+The reset maps and guards are given as a map or a discrete dynamical system of
+type `R` in the vector `resetmaps`. They are indexed by the labels of the
+corresponding transition.
+
+The switching of type `W` is given in the `switchings` vector, indexed by the
+label of the transition.
+
+Additional data can be stored in the `ext` field.
+
 ### Examples
 
 See [the Thermostat example](https://github.com/blegat/HybridSystems.jl/blob/master/examples/Thermostat.ipynb).
 """
-struct HybridSystem{A, S<:AbstractSystem, R<:AbstractMap, W} <: AbstractHybridSystem
+struct HybridSystem{A, S, R, W} <: AbstractHybridSystem
     automaton::A
     modes::AbstractVector{S}
     resetmaps::AbstractVector{R}
@@ -111,7 +119,7 @@ resetmap(hs::HybridSystem, t) = hs.resetmaps[symbol(hs, t)]
 
 Returns the assignment for the transition `t`.
 """
-assignment(hs::HybridSystem, t) = args -> apply(resetmap(hs, t), args)
+assignment(hs::HybridSystem{A,S,R,W}, t) where {A, S<:AbstractSystem, R<:AbstractMap, W} = args -> apply(resetmap(hs, t), args)
 
 """
     guard(hs::HybridSystem, t)

--- a/src/HybridSystems.jl
+++ b/src/HybridSystems.jl
@@ -23,9 +23,8 @@ corresponding labels.
 The mode dynamic and domain are stored in a continuous dynamical system of type
 `S` in the vector `modes`. They are indexed by the discrete states of the
 automaton.
-The reset maps and guards are given as discrete dynamical system or discrete map
-of type `R` in the vector `resetmaps`. They are indexed by the labels of the
-corresponding transition.
+The reset maps and guards are given as a map of type `R` in the vector `resetmaps`.
+They are indexed by the labels of the corresponding transition.
 The switching of type `W` is given in the `switchings` vector,
 indexed by the label of the transition.
 Additional data can be stored in the `ext` field.
@@ -43,11 +42,11 @@ Additional data can be stored in the `ext` field.
                   transition, see [`AbstractSwitching`](@ref).
 - `ext`        -- dictionary that can be used by extensions.
 
-## Examples
+### Examples
 
 See [the Thermostat example](https://github.com/blegat/HybridSystems.jl/blob/master/examples/Thermostat.ipynb).
 """
-struct HybridSystem{A, S, R, W} <: AbstractHybridSystem
+struct HybridSystem{A, S<:AbstractSystem, R<:AbstractMap, W} <: AbstractHybridSystem
     automaton::A
     modes::AbstractVector{S}
     resetmaps::AbstractVector{R}
@@ -78,7 +77,7 @@ for f in [:state_property_type, :transition_property_type]
 end
 
 # System
-export statedim, stateset, inputdim, inputset, guard, assignment, target_mode
+export statedim, stateset, inputdim, inputset, guard, assignment, target_mode, resetmap
 """
     statedim(hs::HybridSystem, u::Int)
 
@@ -101,18 +100,25 @@ Returns the target mode for the transition `t`.
 target_mode(hs::HybridSystem, t) = hs.modes[target(hs, t)]
 
 """
+    resetmap(hs::HybridSystem, t)
+
+Returns the reset map for the transition `t`.
+"""
+resetmap(hs::HybridSystem, t) = hs.resetmaps[symbol(hs, t)]
+
+"""
     assignment(hs::HybridSystem, t)
 
 Returns the assignment for the transition `t`.
 """
-assignment(hs::HybridSystem, t) = hs.resetmaps[symbol(hs, t)]
+assignment(hs::HybridSystem, t) = args -> apply(resetmap(hs, t), args)
 
 """
     guard(hs::HybridSystem, t)
 
 Returns the guard for the transition `t`.
 """
-guard(hs::HybridSystem, t) = stateset(assignment(hs, t))
+guard(hs::HybridSystem, t) = stateset(resetmap(hs, t))
 
 # for completeness, extend the stateset function from MathematicalSystems
 # because guards are given as the state constraints of the reset map

--- a/src/HybridSystems.jl
+++ b/src/HybridSystems.jl
@@ -119,7 +119,7 @@ resetmap(hs::HybridSystem, t) = hs.resetmaps[symbol(hs, t)]
 
 Returns the assignment for the transition `t`.
 """
-assignment(hs::HybridSystem{A,S,R,W}, t) where {A, S<:AbstractSystem, R<:AbstractMap, W} = args -> apply(resetmap(hs, t), args)
+assignment(hs::HybridSystem{A,S,R,W}, t) where {A, S<:AbstractSystem, R<:AbstractMap, W} = (args...) -> apply(resetmap(hs, t), args...)
 
 """
     guard(hs::HybridSystem, t)


### PR DESCRIPTION
This is a rework of https://github.com/blegat/HybridSystems.jl/pull/22.

Note that i added the type annotation `R<:AbstractMap` in `HybridSystem`. The motivation is that if we are going to let `assignment` be the function, then it cannot be `Union{AbstractDiscreteSystem, AbstractMap}` as implied in the previous doc, because the discrete systems do not have an "apply" method.

If you're not convinced i can revert it, letting `assignment` work only when:

```julia
assignment(hs::HybridSystem{A, S, R, W}, t) where {A, S<:AbstractSystem, R<:AbstractMap, W} = ...
``` 

I also added the type annotation `S<:AbstractSystem` in HybridSystem. Becaue we have methods such as `inputset`, `statedim` and so on that make sense if the vector of modes are systems. 