### PR TITLE
#29 - out_transitions for location with no transitions

### DIFF
--- a/src/light.jl
+++ b/src/light.jl
@@ -1,6 +1,8 @@
 import MappedArrays
 import LightGraphs
 
+using MappedArrays: ReadonlyMappedArray
+
 """
     LightAutomaton{GT, ET} <: AbstractAutomaton
 
@@ -167,15 +169,15 @@ event(A::LightAutomaton, t::LightTransition) = A.Σ[t.edge][t.id]
 target(::LightAutomaton, t::LightTransition) = t.edge.dst
 
 function in_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
-    edges = MappedArrays.mappedarray(ET,
-                                     src -> edge_object(A, src, s),
-                                     LightGraphs.inneighbors(A.G, s))
+    f(src) = edge_object(A, src, s)
+    inneigh = LightGraphs.inneighbors(A.G, s)
+    edges = ReadonlyMappedArray{ET, 1, typeof(inneigh), typeof(f)}(f, inneigh)
     LightTransitionIterator(A, edges)
 end
 function out_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
-    edges = MappedArrays.mappedarray(ET,
-                                     dst -> edge_object(A, s, dst),
-                                     LightGraphs.outneighbors(A.G, s))
+    f(dst) = edge_object(A, s, dst)
+    outneigh = LightGraphs.outneighbors(A.G, s)
+    edges = ReadonlyMappedArray{ET, 1, typeof(outneigh), typeof(f)}(f, outneigh)
     LightTransitionIterator(A, edges)
 end
 

--- a/src/light.jl
+++ b/src/light.jl
@@ -108,14 +108,10 @@ function transitions(A::LightAutomaton)
 end
 ntransitions(A::LightAutomaton) = A.nt
 
-function edge_object_no_assertion(A::LightAutomaton, q, r)
-    return LightGraphs.Edge(q, r)
-end
-
 function edge_object(A::LightAutomaton, q, r)
     @assert 1 <= q <= nstates(A)
     @assert 1 <= r <= nstates(A)
-    return edge_object_no_assertion(A, q, r)
+    return LightGraphs.Edge(q, r)
 end
 
 function add_transition!(A::LightAutomaton, q, r, σ)
@@ -170,17 +166,16 @@ source(::LightAutomaton, t::LightTransition) = t.edge.src
 event(A::LightAutomaton, t::LightTransition) = A.Σ[t.edge][t.id]
 target(::LightAutomaton, t::LightTransition) = t.edge.dst
 
-function in_transitions(A::LightAutomaton, s)
-    it = LightGraphs.inneighbors(A.G, s)
-    # MappedArrays.mappedarray over empty array returns 'zero' (see #29)
-    edge_function = isempty(it) ? edge_object_no_assertion : edge_object
-    edges = MappedArrays.mappedarray(src -> edge_function(A, src, s), it)
+function in_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
+    edges = MappedArrays.mappedarray(ET,
+                                     src -> edge_object(A, src, s),
+                                     LightGraphs.inneighbors(A.G, s))
     LightTransitionIterator(A, edges)
 end
-function out_transitions(A::LightAutomaton, s)
-    it = LightGraphs.outneighbors(A.G, s)
-    edge_function = isempty(it) ? edge_object_no_assertion : edge_object
-    edges = MappedArrays.mappedarray(dst -> edge_function(A, s, dst), it)
+function out_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
+    edges = MappedArrays.mappedarray(ET,
+                                     dst -> edge_object(A, s, dst),
+                                     LightGraphs.outneighbors(A.G, s))
     LightTransitionIterator(A, edges)
 end
 

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -68,9 +68,17 @@ end
         t1 = add_transition!(automaton, 1, 2, 1)
         @test has_transition(automaton, 1, 2)
         @test !has_transition(automaton, 1, 1)
+        @test length(out_transitions(automaton, 1)) == 1
+        @test length(out_transitions(automaton, 2)) == 0
+        @test length(in_transitions(automaton, 1)) == 0
+        @test length(in_transitions(automaton, 2)) == 1
         t2 = add_transition!(automaton, 1, 1, 1)
         t3 = add_transition!(automaton, 2, 1, 2)
         @test !has_transition(automaton, 2, 2)
+        @test length(out_transitions(automaton, 1)) == 2
+        @test length(out_transitions(automaton, 2)) == 1
+        @test length(in_transitions(automaton, 1)) == 2
+        @test length(in_transitions(automaton, 2)) == 1
         t4 = add_transition!(automaton, 2, 2, 1)
         t5 = add_transition!(automaton, 1, 2, 2)
         @test has_transition(automaton, t1)


### PR DESCRIPTION
This is one attempt to close #29.
This workaround is not very elegant due to the restriction that I want to make the code type stable. Note that it relies on `LightGraphs` to return an empty list for non-existing nodes. I understand if you do not accept this workaround.