### PR TITLE
Add mode and use continuous system and maps for switched systems

### DIFF
--- a/docs/src/lib/methods.md
+++ b/docs/src/lib/methods.md
@@ -38,6 +38,7 @@ inputset
 states
 nstates
 rem_state!
+mode
 target_mode
 ```
 

--- a/src/HybridSystems.jl
+++ b/src/HybridSystems.jl
@@ -85,27 +85,34 @@ for f in [:state_property_type, :transition_property_type]
 end
 
 # System
-export statedim, stateset, inputdim, inputset, guard, assignment, target_mode, resetmap
+export statedim, stateset, inputdim, inputset, guard, assignment, mode, target_mode, resetmap
 """
     statedim(hs::HybridSystem, u::Int)
 
-Returns the dimension of the state space of the system at mode `u`.
+Returns the dimension of the state space of the system at discrete state `u`.
 """
 MathematicalSystems.statedim(hs::HybridSystem, u::Int) = statedim(hs.modes[u])
 
 """
     stateset(s::AbstractSystem, u::Int)
 
-Returns the set of allowed states of the system at mode `u`.
+Returns the set of allowed states of the system at discrete state `u`.
 """
 MathematicalSystems.stateset(hs::HybridSystem, u::Int) = stateset(hs.modes[u])
 
 """
-    target_mode(hs::HybridSystem, t)
+    mode(hs::HybridSystem, u::Int)
+
+Returns the mode dynamical system at discrete state `u`.
+"""
+mode(hs::HybridSystem, u::Int) = hs.modes[u]
+
+"""
+    target_mode(hs::AbstractHybridSystem, t)
 
 Returns the target mode for the transition `t`.
 """
-target_mode(hs::HybridSystem, t) = hs.modes[target(hs, t)]
+target_mode(hs::AbstractHybridSystem, t) = mode(hs, target(hs, t))
 
 """
     resetmap(hs::HybridSystem, t)
@@ -126,11 +133,11 @@ assignment(hs::HybridSystem{A,S,R,W}, t) where {A, S<:AbstractSystem, R<:Abstrac
 
 Returns the guard for the transition `t`.
 """
-guard(hs::HybridSystem, t) = stateset(resetmap(hs, t))
+guard(hs::AbstractHybridSystem, t) = stateset(resetmap(hs, t))
 
 # for completeness, extend the stateset function from MathematicalSystems
 # because guards are given as the state constraints of the reset map
-MathematicalSystems.stateset(hs::HybridSystem, t) = guard(hs, t)
+MathematicalSystems.stateset(hs::AbstractHybridSystem, t) = guard(hs, t)
 
 """
     inputdim(s::AbstractSystem, u::Int)

--- a/src/HybridSystems.jl
+++ b/src/HybridSystems.jl
@@ -103,7 +103,7 @@ MathematicalSystems.stateset(hs::HybridSystem, u::Int) = stateset(hs.modes[u])
 """
     mode(hs::HybridSystem, u::Int)
 
-Returns the mode dynamical system at discrete state `u`.
+Returns the mode of the dynamical system at discrete state `u`.
 """
 mode(hs::HybridSystem, u::Int) = hs.modes[u]
 

--- a/src/switchedsystems.jl
+++ b/src/switchedsystems.jl
@@ -1,9 +1,9 @@
 using FillArrays
 export discreteswitchedsystem, DiscreteSwitchedLinearSystem, StateDepDiscreteSwitchedLinearSystem, ConstrainedDiscreteSwitchedLinearSystem
 
-const DiscreteSwitchedLinearSystem = HybridSystem{OneStateAutomaton, <:DiscreteIdentitySystem, <:LinearDiscreteSystem, AutonomousSwitching}
-const StateDepDiscreteSwitchedLinearSystem = HybridSystem{<:AbstractAutomaton, <:ConstrainedDiscreteIdentitySystem, <:ConstrainedLinearDiscreteSystem, AutonomousSwitching}
-const ConstrainedDiscreteSwitchedLinearSystem = HybridSystem{<:AbstractAutomaton, <:DiscreteIdentitySystem, <:LinearDiscreteSystem, AutonomousSwitching}
+const DiscreteSwitchedLinearSystem = HybridSystem{OneStateAutomaton, <:ContinuousIdentitySystem, <:LinearMap, AutonomousSwitching}
+const StateDepDiscreteSwitchedLinearSystem = HybridSystem{<:AbstractAutomaton, <:ConstrainedContinuousIdentitySystem, <:ConstrainedLinearMap, AutonomousSwitching}
+const ConstrainedDiscreteSwitchedLinearSystem = HybridSystem{<:AbstractAutomaton, <:ContinuousIdentitySystem, <:LinearMap, AutonomousSwitching}
 
 """
     discreteswitchedsystem(A::AbstractVector{<:AbstractMatrix})
@@ -41,16 +41,16 @@ where ``q_0, \\sigma_1, q_1, \\ldots, q_{k-1}, \\sigma_k, q_k`` is a valid seque
 function discreteswitchedsystem end
 function discreteswitchedsystem(A::AbstractVector{<:AbstractMatrix}, G::AbstractAutomaton=OneStateAutomaton(length(A)); kws...)
     n = nstates(G)
-    modes = DiscreteIdentitySystem.(map(s -> _getstatedim(A, G, s), states(G)))
-    rm = LinearDiscreteSystem.(A)
+    modes = ContinuousIdentitySystem.(map(s -> _getstatedim(A, G, s), states(G)))
+    rm = LinearMap.(A)
     sw = Fill(AutonomousSwitching(), n)
     HybridSystem(G, modes, rm, sw, Dict{Symbol, Any}(kws))
 end
 function discreteswitchedsystem(A::AbstractVector{<:AbstractMatrix}, G::AbstractAutomaton, S::AbstractVector; kws...)
     n = nstates(G)
-    modes = ConstrainedDiscreteIdentitySystem.(map(s -> _getstatedim(A, G, s), states(G)), S)
+    modes = ConstrainedContinuousIdentitySystem.(map(s -> _getstatedim(A, G, s), states(G)), S)
     guards = _guards(A, G, S)
-    rm = ConstrainedLinearDiscreteSystem.(A, guards)
+    rm = ConstrainedLinearMap.(A, guards)
     sw = Fill(AutonomousSwitching(), n)
     HybridSystem(G, modes, rm, sw, Dict{Symbol, Any}(kws))
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -94,6 +94,7 @@ end
             @test nstates(s) == 2
             @test states(s) == 1:2
             for u in states(s)
+                @test mode(s, u) === s.modes[u]
                 @test statedim(s, u) == 2
                 @test stateset(s, u) isa Polyhedra.DefaultPolyhedron{Float64}
             end
@@ -102,7 +103,7 @@ end
             for t in transitions(s)
                 @test stateset(s, t) isa Polyhedra.DefaultPolyhedron{Float64}
                 @test inputset(s, t) isa Polyhedra.DefaultPolyhedron{Float64}
-                @test target_mode(s, t) == s.modes[target(s, t)]
+                @test target_mode(s, t) === s.modes[target(s, t)]
             end
         end
     end


### PR DESCRIPTION
This is breaking as `switchedsystems` now use continuous systems for modes and maps for reset maps.