### PR TITLE
[BREAKING] Rename LightAutomaton/LightTransition to GraphAutomaton/GraphTransition

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "HybridSystems"
 uuid = "2207ec0c-686c-5054-b4d2-543502888820"
 repo = "https://github.com/blegat/HybridSystems.jl.git"
-version = "0.3.6"
+version = "0.4.0"
 
 [deps]
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"

--- a/docs/src/lib/types.md
+++ b/docs/src/lib/types.md
@@ -28,9 +28,9 @@ AbstractAutomaton
 HybridSystems.AbstractTransition
 OneStateAutomaton
 OneStateTransition
-LightAutomaton
-LightAutomaton(::Int)
-HybridSystems.LightTransitionIterator
+GraphAutomaton
+GraphAutomaton(::Int)
+HybridSystems.GraphTransitionIterator
 ```
 
 ## Switchings

--- a/examples/PEDJ16s4.jl
+++ b/examples/PEDJ16s4.jl
@@ -17,7 +17,7 @@ k1 = -0.49
 k2 = 0.27
 As = [A + B * [k1 k2], A + B * [0 k2], A + B * [k1 0], A]
 @assert eltype(As) <: SMatrix
-G = LightAutomaton(4)
+G = GraphAutomaton(4)
 add_transition!(G, 1, 2, 3)
 add_transition!(G, 2, 1, 2)
 add_transition!(G, 1, 3, 1)

--- a/examples/Thermostat.ipynb
+++ b/examples/Thermostat.ipynb
@@ -215,7 +215,7 @@
    "outputs": [],
    "source": [
     "using HybridSystems\n",
-    "a = LightAutomaton(2)\n",
+    "a = GraphAutomaton(2)\n",
     "add_transition!(a, 1, 2, 1)  # off to on\n",
     "add_transition!(a, 2, 1, 2); # on to off"
    ]
@@ -265,7 +265,7 @@
     {
      "data": {
       "text/plain": [
-       "Hybrid System with automaton LightAutomaton{Graphs.SimpleGraphs.SimpleDiGraph{Int64},Graphs.SimpleGraphs.SimpleEdge{Int64}}({2, 2} directed simple Int64 graph, Dict(Edge 1 => 2=>1,Edge 2 => 1=>2))"
+       "Hybrid System with automaton GraphAutomaton{Graphs.SimpleGraphs.SimpleDiGraph{Int64},Graphs.SimpleGraphs.SimpleEdge{Int64}}({2, 2} directed simple Int64 graph, Dict(Edge 1 => 2=>1,Edge 2 => 1=>2))"
       ]
      },
      "execution_count": 8,

--- a/examples/cruise_control.jl
+++ b/examples/cruise_control.jl
@@ -53,7 +53,7 @@ function cruise_control_example(N, M; vmin = 5., vmax = 35., v = (15.6, 24.5), U
         P1 = P0 ∩ Pvmin
     end
 
-    G = LightAutomaton(N)
+    G = GraphAutomaton(N)
     if N == 1
         add_transition!(G, 1, 1, 1)
         safe_sets = [P1 ∩ Pvimax[1]]

--- a/examples/horizontal_jump.jl
+++ b/examples/horizontal_jump.jl
@@ -5,7 +5,7 @@ using HybridSystems
 using Polyhedra
 
 function horizontal_jump_example(lib::Polyhedra.Library, shift::Bool=false)
-    A = LightAutomaton(2)
+    A = GraphAutomaton(2)
     add_transition!(A, 1, 2, 1)
     add_transition!(A, 2, 1, 2)
 

--- a/examples/nocone.jl
+++ b/examples/nocone.jl
@@ -9,7 +9,7 @@
 #const MP = MultivariatePolynomials
 #
 ## Unbounded input
-#function liftinputalg(s::ConstrainedSystem{<:AbstractSystem, LightAutomaton{P, MP.FullSpace}}, c) where P
+#function liftinputalg(s::ConstrainedSystem{<:AbstractSystem, GraphAutomaton{P, MP.FullSpace}}, c) where P
 #    ConstrainedSystem(liftinputalg(s.s), s.a), c
 #end
 #function liftinputalg(s::ConstrainedSystem, c)

--- a/examples/simple_cruise_control.jl
+++ b/examples/simple_cruise_control.jl
@@ -7,7 +7,7 @@ N = 2
 
 using FillArrays
 using HybridSystems
-A = LightAutomaton(N)
+A = GraphAutomaton(N)
 add_transition!(A, 1, 2, 1)
 add_transition!(A, 2, 2, 1)
 ##add_transition!(A, 2, 3, 1)

--- a/examples/square.jl
+++ b/examples/square.jl
@@ -5,7 +5,7 @@ using Polyhedra
 using LinearAlgebra
 
 function square_example(lib::Polyhedra.Library)
-    automaton = LightAutomaton(1)
+    automaton = GraphAutomaton(1)
     add_transition!(automaton, 1, 1, 1)
 
     domain_hrep = HalfSpace([1, 0], 1) ∩ HalfSpace([-1, 0], 1) ∩ HalfSpace([0, 1], 1) ∩ HalfSpace([0, -1], 1)

--- a/src/automata.jl
+++ b/src/automata.jl
@@ -1,4 +1,4 @@
-export LightAutomaton, AbstractAutomaton, OneStateAutomaton
+export GraphAutomaton, AbstractAutomaton, OneStateAutomaton
 export states, modes, nstates, nmodes, transitions, ntransitions
 export source, event, symbol, target, transitiontype
 export add_transition!, has_transition, rem_transition!, rem_state!, add_state!

--- a/src/light.jl
+++ b/src/light.jl
@@ -4,17 +4,17 @@ import Graphs
 using MappedArrays: ReadonlyMappedArray
 
 """
-    LightAutomaton{GT, ET} <: AbstractAutomaton
+    GraphAutomaton{GT, ET} <: AbstractAutomaton
 
 A hybrid automaton that uses the `Graphs` backend. See the constructor
-[`LightAutomaton(::Int)`](@ref).
+[`GraphAutomaton(::Int)`](@ref).
 
 ###  Fields
 
 - `G` -- graph of type `GT` whose vertices determine the states
 - `Σ` -- dictionary mapping the edges to their labels
 """
-mutable struct LightAutomaton{GT, ET} <: AbstractAutomaton
+mutable struct GraphAutomaton{GT, ET} <: AbstractAutomaton
     G::GT
     Σ::Dict{ET, Dict{Int, Int}}
     next_id::Int
@@ -22,9 +22,9 @@ mutable struct LightAutomaton{GT, ET} <: AbstractAutomaton
 end
 
 """
-    LightAutomaton(n::Int)
+    GraphAutomaton(n::Int)
 
-Creates a `LightAutomaton` with `n` states 1, 2, ..., `n`.
+Creates a `GraphAutomaton` with `n` states 1, 2, ..., `n`.
 The automaton is initialized without any transitions,
 use [`add_transition!`](@ref) to add transitions.
 
@@ -34,95 +34,95 @@ To create an automaton with 2 nodes 1, 2, self-loops of labels 1, a transition
 from 1 to 2 with label 2 and transition from 2 to 1 with label 3, do the
 following:
 ```jldoctest
-julia> a = LightAutomaton(2);
+julia> a = GraphAutomaton(2);
 
 julia> add_transition!(a, 1, 1, 1) # Add a self-loop of label 1 for state 1
-HybridSystems.LightTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 1, 1)
+HybridSystems.GraphTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 1, 1)
 
 julia> add_transition!(a, 2, 2, 1) # Add a self-loop of label 1 for state 2
-HybridSystems.LightTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 2, 2)
+HybridSystems.GraphTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 2, 2)
 
 julia> add_transition!(a, 1, 2, 2) # Add a transition from state 1 to state 2 with label 2
-HybridSystems.LightTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 2, 3)
+HybridSystems.GraphTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 1 => 2, 3)
 
 julia> add_transition!(a, 2, 1, 3) # Add a transition from state 2 to state 1 with label 3
-HybridSystems.LightTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 1, 4)
+HybridSystems.GraphTransition{Graphs.SimpleGraphs.SimpleEdge{Int64}}(Edge 2 => 1, 4)
 ```
 """
-function LightAutomaton(n::Int)
+function GraphAutomaton(n::Int)
     G = Graphs.DiGraph(n)
     Σ = Dict{Graphs.edgetype(G), Dict{Int, Int}}()
-    LightAutomaton(G, Σ, 0, 0)
+    GraphAutomaton(G, Σ, 0, 0)
 end
 
-struct LightTransition{ET} <: AbstractTransition
+struct GraphTransition{ET} <: AbstractTransition
     edge::ET
     id::Int
 end
 
 """
-    struct LightTransitionIterator{GT, ET, VT}
-        automaton::LightAutomaton{GT, ET}
+    struct GraphTransitionIterator{GT, ET, VT}
+        automaton::GraphAutomaton{GT, ET}
         edge_iterator::VT
     end
 
 Iterate over the transitions of `automaton` by iterating over the edges `edge`
 of `edge_iterator` and the ids `id` of `automaton.Σ[edge]` for each one. Its
-elements are `LightTransition(edge, id)`.
+elements are `GraphTransition(edge, id)`.
 """
-struct LightTransitionIterator{GT, ET, VT}
-    automaton::LightAutomaton{GT, ET}
+struct GraphTransitionIterator{GT, ET, VT}
+    automaton::GraphAutomaton{GT, ET}
     edge_iterator::VT
 end
-Base.eltype(::LightTransitionIterator{GT, ET}) where {GT, ET} = LightTransition{ET}
-function Base.length(tit::LightTransitionIterator)
+Base.eltype(::GraphTransitionIterator{GT, ET}) where {GT, ET} = GraphTransition{ET}
+function Base.length(tit::GraphTransitionIterator)
     eit = tit.edge_iterator
     # empty iterator must be handled separately (see #29)
     return isempty(eit) ? 0 : sum(edge -> length(tit.automaton.Σ[edge]), eit)
 end
-function new_id_iterate(tit::LightTransitionIterator, edge, edge_state, ids, ::Nothing)
+function new_id_iterate(tit::GraphTransitionIterator, edge, edge_state, ids, ::Nothing)
     return new_edge_iterate(tit, iterate(tit.edge_iterator, edge_state))
 end
-function new_id_iterate(tit::LightTransitionIterator, edge, edge_state, ids, id_item_state)
+function new_id_iterate(tit::GraphTransitionIterator, edge, edge_state, ids, id_item_state)
     idσ, id_state = id_item_state
-    return LightTransition(edge, idσ[1]), (edge, edge_state, ids, id_state)
+    return GraphTransition(edge, idσ[1]), (edge, edge_state, ids, id_state)
 end
-new_edge_iterate(::LightTransitionIterator, ::Nothing) = nothing
-function new_edge_iterate(tit::LightTransitionIterator, edge_item_state)
+new_edge_iterate(::GraphTransitionIterator, ::Nothing) = nothing
+function new_edge_iterate(tit::GraphTransitionIterator, edge_item_state)
     edge, edge_state = edge_item_state
     ids = tit.automaton.Σ[edge]
     return new_id_iterate(tit, edge, edge_state, ids, iterate(ids))
 end
-function Base.iterate(tit::LightTransitionIterator)
+function Base.iterate(tit::GraphTransitionIterator)
     return new_edge_iterate(tit, iterate(tit.edge_iterator))
 end
-function Base.iterate(tit::LightTransitionIterator, edge_id_state)
+function Base.iterate(tit::GraphTransitionIterator, edge_id_state)
     edge, edge_state, ids, id_state = edge_id_state
     return new_id_iterate(tit, edge, edge_state, ids, iterate(ids, id_state))
 end
 
-states(A::LightAutomaton) = Graphs.vertices(A.G)
-nstates(A::LightAutomaton) = Graphs.nv(A.G)
+states(A::GraphAutomaton) = Graphs.vertices(A.G)
+nstates(A::GraphAutomaton) = Graphs.nv(A.G)
 
-transitiontype(A::LightAutomaton) = LightTransition{Graphs.edgetype(A.G)}
-function transitions(A::LightAutomaton)
-    return LightTransitionIterator(A, Graphs.edges(A.G))
+transitiontype(A::GraphAutomaton) = GraphTransition{Graphs.edgetype(A.G)}
+function transitions(A::GraphAutomaton)
+    return GraphTransitionIterator(A, Graphs.edges(A.G))
 end
-ntransitions(A::LightAutomaton) = A.nt
+ntransitions(A::GraphAutomaton) = A.nt
 
-function edge_object(A::LightAutomaton, q, r)
+function edge_object(A::GraphAutomaton, q, r)
     @assert 1 <= q <= nstates(A)
     @assert 1 <= r <= nstates(A)
     return Graphs.Edge(q, r)
 end
 
 # return transitions with source `q` and target `r`
-function transitions(A::LightAutomaton{GT, ET}, q, r) where {GT, ET}
+function transitions(A::GraphAutomaton{GT, ET}, q, r) where {GT, ET}
     e = edge_object(A, q, r)
-    LightTransitionIterator(A, Fill(e, Graphs.has_edge(A.G, e) ? 1 : 0))
+    GraphTransitionIterator(A, Fill(e, Graphs.has_edge(A.G, e) ? 1 : 0))
 end
 
-function add_transition!(A::LightAutomaton, q, r, σ)
+function add_transition!(A::GraphAutomaton, q, r, σ)
     edge = edge_object(A, q, r)
     A.next_id += 1
     A.nt += 1
@@ -137,15 +137,15 @@ function add_transition!(A::LightAutomaton, q, r, σ)
         Graphs.add_edge!(A.G, edge)
         A.Σ[edge] = ids
     end
-    return LightTransition(edge, id)
+    return GraphTransition(edge, id)
 end
-function has_transition(A::LightAutomaton, q, r)
+function has_transition(A::GraphAutomaton, q, r)
     return Graphs.has_edge(A.G, edge_object(A, q, r))
 end
-function has_transition(A::LightAutomaton, t::LightTransition)
+function has_transition(A::GraphAutomaton, t::GraphTransition)
     return Graphs.has_edge(A.G, t.edge) && haskey(A.Σ[t.edge], t.id)
 end
-function rem_transition!(A::LightAutomaton, t::LightTransition)
+function rem_transition!(A::GraphAutomaton, t::GraphTransition)
     ids = A.Σ[t.edge]
     delete!(ids, t.id)
     A.nt -= 1
@@ -155,7 +155,7 @@ function rem_transition!(A::LightAutomaton, t::LightTransition)
     end
 end
 
-function rem_state!(A::LightAutomaton, st)
+function rem_state!(A::GraphAutomaton, st)
     # We need to collect as we delete them in the loop
     for t in collect(in_transitions(A, st))
         rem_transition!(A, t)
@@ -166,62 +166,62 @@ function rem_state!(A::LightAutomaton, st)
     return Graphs.rem_vertex!(A.G, st)
 end
 
-function add_state!(A::LightAutomaton)
+function add_state!(A::GraphAutomaton)
     return Graphs.add_vertex!(A.G)
 end
 
-source(::LightAutomaton, t::LightTransition) = t.edge.src
-event(A::LightAutomaton, t::LightTransition) = A.Σ[t.edge][t.id]
-target(::LightAutomaton, t::LightTransition) = t.edge.dst
+source(::GraphAutomaton, t::GraphTransition) = t.edge.src
+event(A::GraphAutomaton, t::GraphTransition) = A.Σ[t.edge][t.id]
+target(::GraphAutomaton, t::GraphTransition) = t.edge.dst
 
-function in_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
+function in_transitions(A::GraphAutomaton{GT, ET}, s) where {GT, ET}
     f(src) = edge_object(A, src, s)
     inneigh = Graphs.inneighbors(A.G, s)
     edges = ReadonlyMappedArray{ET, 1, typeof(inneigh), typeof(f)}(f, inneigh)
-    LightTransitionIterator(A, edges)
+    GraphTransitionIterator(A, edges)
 end
-function out_transitions(A::LightAutomaton{GT, ET}, s) where {GT, ET}
+function out_transitions(A::GraphAutomaton{GT, ET}, s) where {GT, ET}
     f(dst) = edge_object(A, s, dst)
     outneigh = Graphs.outneighbors(A.G, s)
     edges = ReadonlyMappedArray{ET, 1, typeof(outneigh), typeof(f)}(f, outneigh)
-    LightTransitionIterator(A, edges)
+    GraphTransitionIterator(A, edges)
 end
 
-struct LightStateProperty{GT, ET, T} <: StateProperty{T}
-    automaton::LightAutomaton{GT, ET}
+struct GraphStateProperty{GT, ET, T} <: StateProperty{T}
+    automaton::GraphAutomaton{GT, ET}
     value::Vector{T}
 end
-function state_property_type(::Type{LightAutomaton{GT, ET}},
+function state_property_type(::Type{GraphAutomaton{GT, ET}},
                              T::Type) where {GT, ET}
-    return LightStateProperty{GT, ET, T}
+    return GraphStateProperty{GT, ET, T}
 end
-function state_property(automaton::LightAutomaton, T::Type)
-    return LightStateProperty(automaton, Vector{T}(undef, nstates(automaton)))
+function state_property(automaton::GraphAutomaton, T::Type)
+    return GraphStateProperty(automaton, Vector{T}(undef, nstates(automaton)))
 end
-function Base.getindex(p::LightStateProperty,
+function Base.getindex(p::GraphStateProperty,
                        s::Int)
     p.value[s]
 end
-function Base.setindex!(p::LightStateProperty, value,
+function Base.setindex!(p::GraphStateProperty, value,
                         s::Int)
     p.value[s] = value
 end
 
-struct LightTransitionProperty{GT, ET, T} <: TransitionProperty{T}
-    automaton::LightAutomaton{GT, ET}
+struct GraphTransitionProperty{GT, ET, T} <: TransitionProperty{T}
+    automaton::GraphAutomaton{GT, ET}
     value::Vector{T}
 end
-function transition_property_type(::Type{LightAutomaton{GT, ET}}, T::Type) where {GT, ET}
-    return LightTransitionProperty{GT, ET, T}
+function transition_property_type(::Type{GraphAutomaton{GT, ET}}, T::Type) where {GT, ET}
+    return GraphTransitionProperty{GT, ET, T}
 end
-function transition_property(automaton::LightAutomaton, T::Type)
-    return LightTransitionProperty(automaton, Vector{T}(undef, automaton.next_id))
+function transition_property(automaton::GraphAutomaton, T::Type)
+    return GraphTransitionProperty(automaton, Vector{T}(undef, automaton.next_id))
 end
-function Base.getindex(p::LightTransitionProperty,
-                       t::LightTransition)
+function Base.getindex(p::GraphTransitionProperty,
+                       t::GraphTransition)
     p.value[t.id]
 end
-function Base.setindex!(p::LightTransitionProperty, value,
-                        t::LightTransition)
+function Base.setindex!(p::GraphTransitionProperty, value,
+                        t::GraphTransition)
     p.value[t.id] = value
 end

--- a/src/switchedsystems.jl
+++ b/src/switchedsystems.jl
@@ -55,7 +55,7 @@ function discreteswitchedsystem(A::AbstractVector{<:AbstractMatrix}, G::Abstract
     HybridSystem(G, modes, rm, sw, Dict{Symbol, Any}(kws))
 end
 function discreteswitchedsystem(A::AbstractVector{<:AbstractMatrix}, S::AbstractVector; kws...)
-    G = LightAutomaton(length(A))
+    G = GraphAutomaton(length(A))
     for σ in 1:length(A)
         for σnext in 1:length(A)
             add_transition!(G, σ, σnext, σ)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -63,8 +63,8 @@ end
         @test !has_transition(automaton, HybridSystems.OneStateTransition(7))
     end
 
-    @testset "LightAutomaton" begin
-        automaton = LightAutomaton(2)
+    @testset "GraphAutomaton" begin
+        automaton = GraphAutomaton(2)
         @test isempty(transitions(automaton, 1, 2))
         @test length(transitions(automaton, 1, 2)) == 0
         t1 = add_transition!(automaton, 1, 2, 1)

--- a/test/automata.jl
+++ b/test/automata.jl
@@ -6,7 +6,7 @@ function test_state_prop(automaton)
     @test typeof(prop) == HybridSystems.state_property_type(typeof(automaton), Float64)
     prop[1] = 0.5
     @test prop[1] == 0.5
-    iprop = HybridSystems.typed_map(Int, x -> convert(Int, ceil(x)), prop)
+    iprop = HybridSystems.typed_map(Int, x -> ceil(Int, x), prop)
     @test typeof(iprop) == HybridSystems.state_property_type(typeof(automaton), Int)
     @test iprop[1] == 1
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -112,11 +112,11 @@ end
         for sym in (false, true)
             s = cruise_control_example(7, 1, sym=sym)
             @test nstates(s) == 7
-            @test transitiontype(s) == HybridSystems.LightTransition{Graphs.SimpleGraphs.SimpleEdge{Int}}
+            @test transitiontype(s) == HybridSystems.GraphTransition{Graphs.SimpleGraphs.SimpleEdge{Int}}
             t = first(transitions(s))
             @test target(s, t) == 1
             @test source(s, t) == 1
-            #@test sprint(show, s) == "Hybrid System with automaton HybridSystems.LightAutomaton{Graphs.SimpleGraphs.SimpleDiGraph{Int},Graphs.SimpleGraphs.SimpleEdge{Int}}({7, 21} directed simple Int graph, Dict(Edge 2 => 3=>2,Edge 6 => 5=>1,Edge 2 => 1=>1,Edge 4 => 4=>1,Edge 4 => 3=>2,Edge 3 => 6=>2,Edge 6 => 3=>2,Edge 4 => 6=>2,Edge 7 => 7=>1,Edge 6 => 6=>2,Edge 3 => 2=>1,Edge 5 => 4=>1,Edge 5 => 6=>2,Edge 7 => 6=>2,Edge 1 => 3=>2,Edge 5 => 3=>2,Edge 2 => 6=>2,Edge 1 => 1=>1,Edge 1 => 6=>2,Edge 3 => 3=>2,Edge 7 => 3=>2))"
+            #@test sprint(show, s) == "Hybrid System with automaton HybridSystems.GraphAutomaton{Graphs.SimpleGraphs.SimpleDiGraph{Int},Graphs.SimpleGraphs.SimpleEdge{Int}}({7, 21} directed simple Int graph, Dict(Edge 2 => 3=>2,Edge 6 => 5=>1,Edge 2 => 1=>1,Edge 4 => 4=>1,Edge 4 => 3=>2,Edge 3 => 6=>2,Edge 6 => 3=>2,Edge 4 => 6=>2,Edge 7 => 7=>1,Edge 6 => 6=>2,Edge 3 => 2=>1,Edge 5 => 4=>1,Edge 5 => 6=>2,Edge 7 => 6=>2,Edge 1 => 3=>2,Edge 5 => 3=>2,Edge 2 => 6=>2,Edge 1 => 1=>1,Edge 1 => 6=>2,Edge 3 => 3=>2,Edge 7 => 3=>2))"
             @test iszero(inputdim(s, 1))
             @test iszero(inputdim(s, 2))
         end


### PR DESCRIPTION
The previous name wasn't a particularly good description, it was just inspired from the name LightGraphs.
Since LightGraphs was renamed into Graphs, there is now no good reason to keep that name.