### PR TITLE
Fix test on 32-bit systems

### DIFF
--- a/test/automata.jl
+++ b/test/automata.jl
@@ -4,7 +4,9 @@ using HybridSystems
 function test_state_prop(automaton)
     prop = HybridSystems.state_property(automaton, Float64)
     @test typeof(prop) == HybridSystems.state_property_type(typeof(automaton), Float64)
-    prop[1] = 0.5
+    for i in 1:nstates(automaton)
+        prop[i] = 0.5
+    end
     @test prop[1] == 0.5
     iprop = HybridSystems.typed_map(Int, x -> ceil(Int, x), prop)
     @test typeof(iprop) == HybridSystems.state_property_type(typeof(automaton), Int)


### PR DESCRIPTION
See #55 (I found out that the 32-bit version of Julia can be run on 64-bit systems, so debugging was easy).

The problem is that `prop` has length 2 in the second call to the test function `test_state_prop` and then only the first entry is initialized. The other entry contains a random number, which is usually a very small number close to 0, and apparently this can cause issues with `trunc`. So in this PR I just also initialize the second entry. I am not sure whether not initializing was on purpose.